### PR TITLE
Add actor_score_algo_fn

### DIFF
--- a/lib/fun_with_flags/protocols/actor.ex
+++ b/lib/fun_with_flags/protocols/actor.ex
@@ -141,10 +141,16 @@ defmodule FunWithFlags.Actor.Percentage do
   # %_ratio : 1.0 = 16_bits : 65_536
   #
   defp _actor_score(string) do
-    <<score :: size(16), _rest :: binary>> = :crypto.hash(:sha256, string)
-    score / 65_536
+    case Application.get_env(:fun_with_flags, :actor_score_algo_fn, []) do
+      algo_fn when is_function(algo_fn, 1) -> algo_fn.(string)
+      _ -> _default_actor_score(string)
+    end
   end
 
+  defp _default_actor_score(string) do
+    <<score::size(16), _rest::binary>> = :crypto.hash(:sha256, string)
+    score / 65_536
+  end
 
   # To verify that the distribution is uniform
   #


### PR DESCRIPTION
We're using a Ruby feature flag lib (rollout) in a different service that uses a different scoring algorithm. It would be nice to have them share the same algorithm.

Something like this:
```
defmodule FeatureManager do
  def actor_score_algo_fn(string) do
    rand_base = :math.pow(2, 32) - 1
    (CRC.crc(:crc_32, string) / rand_base
  end
end
```

and in configs:
```
config :fun_with_flags,
  actor_score_algo_fn: &FeatureManager.actor_score_algo_fn/1
```